### PR TITLE
Brought code in line with PEP8, added (optional) Game World interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,7 @@ ENV/
 doc/_build
 
 *.swp
+
+# PyCharm IDE files
+.git/
+.idea/

--- a/demo_game.py
+++ b/demo_game.py
@@ -1,8 +1,9 @@
+"""Demonstration game"""
 from adventurelib import *
 
 Room.items = Bag()
 
-current_room = starting_room = Room("""
+starting_room = Room("""
 You are in a dark room.
 """)
 
@@ -11,58 +12,61 @@ You are in a beautiful valley.
 """)
 
 mallet = Item('rusty mallet', 'mallet')
-valley.items = Bag({mallet,})
-
-inventory = Bag()
+valley.items = Bag({mallet, })
 
 
 @when('north', direction='north')
 @when('south', direction='south')
 @when('east', direction='east')
 @when('west', direction='west')
-def go(direction):
-    global current_room
-    room = current_room.exit(direction)
+def go(direction, game):
+    room = game.current_room.exit(direction)
     if room:
-        current_room = room
-        say('You go %s.' % direction)
-        look()
+        game.current_room = room
+        game.say('You go %s.' % direction)
+        look(game)
 
 
 @when('take ITEM')
-def take(item):
-    obj = current_room.items.take(item)
+def take(item, game):
+    obj = game.current_room.items.take(item)
     if obj:
-        say('You pick up the %s.' % obj)
-        inventory.add(obj)
+        game.say('You pick up the %s.' % obj)
+        game.inventory.add(obj)
     else:
-        say('There is no %s here.' % item)
+        game.say('There is no %s here.' % item)
 
 
 @when('drop THING')
-def drop(thing):
-    obj = inventory.take(thing)
+def drop(thing, game):
+    obj = game.inventory.take(thing)
     if not obj:
-        say('You do not have a %s.' % thing)
+        game.say('You do not have a %s.' % thing)
     else:
-        say('You drop the %s.' % obj)
-        current_room.items.add(obj)
+        game.say('You drop the %s.' % obj)
+        game.current_room.items.add(obj)
 
 
 @when('look')
-def look():
-    say(current_room)
-    if current_room.items:
-        for i in current_room.items:
-            say('A %s is here.' % i)
+def look(game):
+    game.say(game.current_room)
+    if game.current_room.items:
+        for i in game.current_room.items:
+            game.say('A %s is here.' % i)
 
 
 @when('inventory')
-def show_inventory():
-    say('You have:')
-    for thing in inventory:
-        say(thing)
+def show_inventory(game):
+    game.say('You have:')
+    for thing in game.inventory:
+        game.say(thing)
+
+        
+def setup(game):
+    """Set up the game world"""
+    game.current_room = starting_room
+    game.inventory = Bag()
+    look(game)
 
 
-look()
-start()
+start(setup)

--- a/test_adventurelib.py
+++ b/test_adventurelib.py
@@ -1,4 +1,3 @@
-import os
 from unittest.mock import patch
 from contextlib import redirect_stdout
 from io import StringIO
@@ -122,9 +121,9 @@ def test_register_args():
     args = None
 
     @when('north', dir='north')
-    def func(dir):
+    def func(direc):
         nonlocal args
-        args = [dir]
+        args = [direc]
     _handle_command('north')
     assert args == ['north']
 
@@ -186,30 +185,19 @@ def test_say_wrap2():
 
 def test_say_paragraph():
     out = say_at_width(40, """
-    This is a long sentence that the say command will wrap.
+    This is a long sentence that the say command will wrap,
+    and this clause is indented to match.
 
     And this is a second paragraph that is separately wrapped.
     """)
 
     assert out == (
         "This is a long sentence that the say\n"
-        "command will wrap.\n"
+        "command will wrap, and this clause is\n"
+        "indented to match.\n"
         "\n"
         "And this is a second paragraph that is\n"
         "separately wrapped.\n"
-    )
-
-
-def test_say_paragraph():
-    out = say_at_width(40, """
-    This is a long sentence that the say command will wrap,
-    and this clause is indented to match.
-    """)
-
-    assert out == (
-        "This is a long sentence that the say\n"
-        "command will wrap, and this clause is\n"
-        "indented to match.\n"
     )
 
 


### PR DESCRIPTION
The "Game World interface" is basically just a way to not keep facts about the world in the global scope, instead using an optional `game` argument to functions that (in theory) includes data about the player and world state and stuff. Also, `say` is now `game.say`, and different input/output interfaces can be used (terminal by default, but any object that inherits from `adventurelib.Interface` and defines `obj.say(string)` and `obj.get_command(prompt) -> str` can be used for input/output.

I also updated the demo to match, deleted unused imports, and fixed an apparent error with the fallback for getting terminal size (it was `try-except-else`, but that would mean that the fallback is used if `shutil` is present iirc; it should've been `try-except(try-except)`).