### PR TITLE
Make the import of readline conditional for, eg, Windows

### DIFF
--- a/adventurelib.py
+++ b/adventurelib.py
@@ -1,7 +1,10 @@
 import re
 import sys
 import inspect
-import readline  # noqa: adds readline semantics to input()
+try:
+    import readline  # noqa: adds readline semantics to input()
+except ImportError:
+    pass
 import textwrap
 import random
 from copy import deepcopy


### PR DESCRIPTION
Ensure the module can install and run on Windows where readline is typically not available

AFAICT it's a nice-to-have for the module in general, so a simple conditional import seems reasonable