### PR TITLE
Added check for duplicate identifiers

### DIFF
--- a/adventurelib.py
+++ b/adventurelib.py
@@ -332,7 +332,7 @@ class Pattern:
                 if arg in argnames:
                     raise InvalidCommand(
                             'Invalid command %r' % pattern +
-                            '\nIdentifiers may only be used once'
+                            ' Identifiers may only be used once'
                             )
                 argnames.append(arg)
                 match.append(Placeholder(arg))

--- a/adventurelib.py
+++ b/adventurelib.py
@@ -331,7 +331,7 @@ class Pattern:
                 arg = w.lower()
                 if arg in argnames:
                     raise InvalidCommand(
-                            'Invalid command %r' % pattern + 
+                            'Invalid command %r' % pattern +
                             '\nIdentifiers may only be used once'
                             )
                 argnames.append(arg)

--- a/adventurelib.py
+++ b/adventurelib.py
@@ -329,6 +329,11 @@ class Pattern:
                 )
             if w.isupper():
                 arg = w.lower()
+                if arg in argnames:
+                    raise InvalidCommand(
+                            'Invalid command %r' % pattern + 
+                            '\nIdentifiers may only be used once'
+                            )
                 argnames.append(arg)
                 match.append(Placeholder(arg))
                 self.placeholders += 1

--- a/test_adventurelib.py
+++ b/test_adventurelib.py
@@ -361,3 +361,8 @@ def test_validate_context_wrong():
         adventurelib._validate_context(".foo.bar.")
     err = str(exc.value)
     assert err == "Context '.foo.bar.' may not start with . or end with ."
+
+def test_validate_pattern_double_ident():
+    """A pattern with identifier used twice is incorrect"""
+    with pytest.raises(adventurelib.InvalidCommand) as exc:
+        pat = Pattern("take ITEM with ITEM")

--- a/test_adventurelib.py
+++ b/test_adventurelib.py
@@ -362,7 +362,11 @@ def test_validate_context_wrong():
     err = str(exc.value)
     assert err == "Context '.foo.bar.' may not start with . or end with ."
 
+
 def test_validate_pattern_double_ident():
     """A pattern with identifier used twice is incorrect"""
     with pytest.raises(adventurelib.InvalidCommand) as exc:
-        pat = Pattern("take ITEM with ITEM")
+        Pattern("take I with I")
+    err = str(exc.value)
+    assert err == "Invalid command 'take I with I'"\
+                  " Identifiers may only be used once"


### PR DESCRIPTION
This pull request implements a simple check when iterating through a command; When it encounters an argument/identifier, it checks if the argument is present in the argument array (It would be if it's duplicate). If so, an error is raised. Resolves #18