### PR TITLE
Add Prompt Toolkit as an optional dependency

### DIFF
--- a/adventurelib.py
+++ b/adventurelib.py
@@ -2,9 +2,15 @@ import re
 import sys
 import inspect
 try:
+    # use prompt toolkit as input if available
     from prompt_toolkit import prompt as input
 except ImportError:
-    pass
+    try:
+        # augment input with readline if available
+        import readline
+    except ImportError:
+        # fall back to standard input command
+        pass
 import textwrap
 import random
 from copy import deepcopy

--- a/adventurelib.py
+++ b/adventurelib.py
@@ -2,7 +2,7 @@ import re
 import sys
 import inspect
 try:
-    import readline  # noqa: adds readline semantics to input()
+    from prompt_toolkit import prompt as input
 except ImportError:
     pass
 import textwrap

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,9 @@ from setuptools import setup
 from adventurelib import __version__
 
 requirements = []
-
+extras_require = {
+    'prompt_toolkit':  ["prompt_toolkit"]
+}
 
 try:
     from shutil import get_terminal_size  # noqa
@@ -21,6 +23,7 @@ setup(
     url='https://adventurelib.readthedocs.io/',
     py_modules=['adventurelib'],
     install_requires=requirements,
+    extras_require=extras_require,
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Education',

--- a/tox.ini
+++ b/tox.ini
@@ -7,5 +7,5 @@ deps=flake8
 commands=flake8 adventurelib.py test_adventurelib.py
 
 [testenv]
-deps = pytest
+deps = pytest prompt_toolkit
 commands = py.test --basetemp={envtmpdir}


### PR DESCRIPTION
[Prompt toolkit](https://github.com/prompt-toolkit/python-prompt-toolkit) is a modern cross-platform Python replacement for GNU readline.

This PR add support for prompt toolkit if it is available, falling back to readline and/or standard `input` if it is not available.  It also adds it as an optional install option via `pip` (ie. you should be able to install it via `pip install adventurelib[prompt_toolkit]`) and is added to the `tox.ini` for testing.