### PR TITLE
setup.py: Add long_description, repository url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,10 @@
+from os.path import abspath, dirname, join
 from setuptools import setup
 from adventurelib import __version__
+
+
+ROOT = abspath(dirname(__file__))
+
 
 requirements = []
 
@@ -11,14 +16,18 @@ except ImportError:
         'backports.shutil_get_terminal_size',
     )
 
+with open(join(ROOT, "README.md")) as fd:
+    README = fd.read()
 
 setup(
     name='adventurelib',
     description='Easy text adventures',
+    long_description=README,
+    long_description_content_type="text/markdown",
     version=__version__,
     author='Daniel Pope',
     author_email='mauve@mauveweb.co.uk',
-    url='https://adventurelib.readthedocs.io/',
+    url='https://github.com/lordmauve/adventurelib',
     py_modules=['adventurelib'],
     install_requires=requirements,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,9 @@ setup(
     author='Daniel Pope',
     author_email='mauve@mauveweb.co.uk',
     url='https://github.com/lordmauve/adventurelib',
+    project_urls={
+        'Documentation': 'https://adventurelib.readthedocs.io/'
+    },
     py_modules=['adventurelib'],
     install_requires=requirements,
     classifiers=[


### PR DESCRIPTION
This PR modifies the existing _setup.py_ file based on requirements listed in issue #13.

- replaces current "UNKNOWN" project description on PyPi with contents of _README.md_
- changes PyPi Homepage URL from documentation URL to GitHub repository URL