### PR TITLE
Issue #24: Output colors with say

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ ENV/
 doc/_build
 
 *.swp
+
+# VS Code project settings
+.vscode

--- a/adventurelib.py
+++ b/adventurelib.py
@@ -6,6 +6,7 @@ try:
 except ImportError:
     pass
 import textwrap
+import font_styles
 import random
 from copy import deepcopy
 try:
@@ -536,7 +537,7 @@ def start(help=True):
         _handle_command(cmd)
 
 
-def say(msg):
+def say(msg, fg='default', bg='default'):
     """Print a message.
 
     Unlike print(), this deals with de-denting and wrapping of text to fit
@@ -546,11 +547,13 @@ def say(msg):
     separately.
 
     """
-    msg = str(msg)
+    text_format = font_styles.text_color(fg) + font_styles.background_color(bg)
+    msg = text_format + str(msg) + font_styles.reset_formatting()
     msg = re.sub(r'^[ \t]*(.*?)[ \t]*$', r'\1', msg, flags=re.M)
     width = get_terminal_size()[0]
     paragraphs = re.split(r'\n(?:[ \t]*\n)', msg)
     formatted = (textwrap.fill(p.strip(), width=width) for p in paragraphs)
+
     print('\n\n'.join(formatted))
 
 

--- a/demo_game.py
+++ b/demo_game.py
@@ -59,7 +59,7 @@ def drop(thing):
 
 @when('look')
 def look():
-    say(current_room)
+    say(current_room, 'black', 'cyan')
     if current_room.items:
         for i in current_room.items:
             say('A %s is here.' % i)

--- a/demo_game.py
+++ b/demo_game.py
@@ -67,7 +67,7 @@ def look():
 
 @when('inventory')
 def show_inventory():
-    say('You have:')
+    say('You have:', 'yellow')
     for thing in inventory:
         say(thing)
 

--- a/font_styles.py
+++ b/font_styles.py
@@ -1,0 +1,51 @@
+TEXT_WHITE = '\u001b[37;1m'
+TEXT_BLACK = '\u001b[30;1m'
+TEXT_RED = '\u001b[31;1m'  
+TEXT_BLUE = '\u001b[34;1m'
+TEXT_CYAN = '\u001b[36;1m'
+TEXT_MAGENTA = '\u001b[35;1m'
+TEXT_GREEN = '\u001b[32;1m'
+TEXT_YELLOW = '\u001b[33;1m'
+
+BG_WHITE = '\u001b[47;1m'
+BG_BLACK = '\u001b[40;1m'
+BG_RED = '\u001b[41;1m'  
+BG_BLUE = '\u001b[44;1m'
+BG_CYAN = '\u001b[46;1m'
+BG_MAGENTA = '\u001b[45;1m'
+BG_GREEN = '\u001b[42;1m'
+BG_YELLOW = '\u001b[43;1m'
+
+RESET = '\u001b[0m'
+
+
+def text_color(option):
+    switcher = {
+        'white': TEXT_WHITE,
+        'black': TEXT_BLACK,
+        'red': TEXT_RED,
+        'blue': TEXT_BLUE,
+        'cyan': TEXT_CYAN,
+        'magenta': TEXT_MAGENTA,
+        'green': TEXT_GREEN,
+        'yellow': TEXT_YELLOW
+    }
+
+    return switcher.get(option, '')
+
+def background_color(option):
+    switcher = {
+        'white': BG_WHITE,
+        'black': BG_BLACK,
+        'red': BG_RED,
+        'blue': BG_BLUE,
+        'cyan': BG_CYAN,
+        'magenta': BG_MAGENTA,
+        'green': BG_GREEN,
+        'yellow': BG_YELLOW
+    }
+
+    return switcher.get(option, '')
+
+def reset_formatting():
+    return RESET

--- a/test_adventurelib.py
+++ b/test_adventurelib.py
@@ -188,7 +188,7 @@ def test_say_room():
     buf = StringIO()
     with redirect_stdout(buf):
         say(r)
-    assert buf.getvalue() == 'You are standing in a hallway.\n'
+    assert buf.getvalue() == 'You are standing in a hallway.' + u'\u001b[0m\n'
 
 
 def test_say_wrap():
@@ -199,7 +199,7 @@ def test_say_wrap():
 
     assert out == (
         "This is a long sentence that the say\n"
-        "command will wrap.\n"
+        "command will wrap. " + u"\u001b[0m\n"
     )
 
 
@@ -213,7 +213,7 @@ def test_say_wrap2():
         "This is a long\n"
         "sentence that the\n"
         "say command will\n"
-        "wrap.\n"
+        "wrap. " + u"\u001b[0m\n"
     )
 
 
@@ -230,9 +230,8 @@ def test_say_multiple_paragraph():
         "command will wrap.\n"
         "\n"
         "And this is a second paragraph that is\n"
-        "separately wrapped.\n"
+        "separately wrapped. " + u"\u001b[0m\n"
     )
-
 
 def test_say_multiline_paragraph():
     """We can wrap a sentence written in multiple input lines."""
@@ -244,9 +243,16 @@ def test_say_multiline_paragraph():
     assert out == (
         "This is a long sentence that the say\n"
         "command will wrap, and this clause is\n"
-        "indented to match.\n"
+        "indented to match. " + u"\u001b[0m\n"
     )
 
+def test_say_room_colored():
+    r = Room('You are standing in a hallway.')
+
+    buf = StringIO()
+    with redirect_stdout(buf):
+        say(r, 'yellow', 'cyan')
+    assert buf.getvalue() == '\u001b[33;1m\u001b[46;1mYou are standing in a hallway.' + u'\u001b[0m\n'
 
 @patch('random.randrange', return_value=0)
 def test_bag_get_random(randrange):


### PR DESCRIPTION
Added `say` output coloring. It is now possible to change font color and text background color.
The following color options have been implemented both for font and background:

- white
- black
- red
- blue
- cyan
- magenta
- green
- yellow

Tests have been adjusted.

Closes #24 