### PR TITLE
Fixes Bag.find(). Restores true (semi-)random behavior to Bag.(take|get)_random.

### DIFF
--- a/adventurelib.py
+++ b/adventurelib.py
@@ -230,7 +230,7 @@ class Bag(set):
         super().__init__(*args, **kwargs)
         self._alias_dict = {}
         for item in self:
-            self._add(item)
+            self._add_aliases(item)
 
     #######
     # Convenience functions to update internal alias dict.
@@ -254,7 +254,7 @@ class Bag(set):
     ####### 
     def add(self, item):
         super().add(item)
-        self._add(item)
+        self._add_aliases(item)
 
     def clear(self):
         super().clear()
@@ -318,9 +318,13 @@ class Bag(set):
         """Find an object in the bag by name, but do not remove it.
 
         Return None if the name does not match.
+        
+        If more than one object with the same name exists, returns one of them.
 
         """
-        return self._alias_dict.get(name)
+        name = name.lower()
+        for element in self._alias_dict.get(name, []):
+            return element
 
     def __contains__(self, v):
         """Return True if an Item is present in the bag.
@@ -353,10 +357,12 @@ class Bag(set):
         Return None if the bag is empty.
 
         """
-        result = self.take_random()
-        if result is not None:
-            self.add(result)
-        return result
+        if not self:
+            return None
+        which = random.randrange(len(self))
+        for index, obj in enumerate(self):
+            if index == which:
+                return obj
 
     def take_random(self):
         """Remove an Item from the bag at random, and return it.
@@ -364,10 +370,10 @@ class Bag(set):
         Return None if the bag is empty.
 
         """
-        try:
-            return self.pop()
-        except KeyError:
-            return None
+        obj = self.get_random()
+        if obj is not None:
+            self.remove(obj)
+        return obj
 
 
 def _register(command, func, context=None, kwargs={}):

--- a/test_adventurelib.py
+++ b/test_adventurelib.py
@@ -251,7 +251,7 @@ def test_say_multiline_paragraph():
 @patch('random.randrange', return_value=0)
 def test_bag_get_random(randrange):
     """We can select an item from a bag at random."""
-    bag = Bag(['a', 'b', 'c'])
+    bag = Bag(map(Item, 'abc'))
     assert bag.get_random() == list(bag)[0]
     randrange.assert_called_once_with(3)
 
@@ -259,7 +259,7 @@ def test_bag_get_random(randrange):
 @patch('random.randrange', return_value=1)
 def test_bag_get_random2(randrange):
     """We can select an item from a bag at random."""
-    bag = Bag(['a', 'b', 'c'])
+    bag = Bag(map(Item, 'abc'))
     assert bag.get_random() == list(bag)[1]
     randrange.assert_called_once_with(3)
 
@@ -273,7 +273,7 @@ def test_empty_bag_get_random():
 @patch('random.randrange', return_value=0)
 def test_bag_take_random(randrange):
     """We can select and remove an item from a bag at random."""
-    bag = Bag(['a', 'b', 'c'])
+    bag = Bag(map(Item, 'abc'))
     items = list(bag)
     assert bag.take_random() == items[0]
     assert bag == Bag(items[1:])
@@ -283,15 +283,17 @@ def test_bag_take_random(randrange):
 def test_bag_find():
     """We can find items in a bag by name, case insensitively."""
     name, *aliases = ['Name', 'UPPER ALIAS', 'lower alias']
-    bag = Bag({
-        Item(name, *aliases)
-    })
+    named_item = Item(name, *aliases)
+    appellative_item = Item('appellation', *aliases)
+    nameless_item = Item('noname', 'none at all')
+    bag = Bag({named_item, appellative_item, nameless_item})
 
-    assert bag.find('name')
-    assert bag.find('Name')
-    assert bag.find('NAME')
-    assert bag.find('upper alias')
-    assert bag.find('LOWER ALIAS')
+    assert bag.find('name') is named_item
+    assert bag.find('Name') is named_item
+    assert bag.find('NAME') is named_item
+    assert bag.find('appellation') is appellative_item
+    assert bag.find('upper alias') in {named_item, appellative_item}
+    assert bag.find('LOWER ALIAS') in {named_item, appellative_item}
     assert not bag.find('other')
 
 


### PR DESCRIPTION
My PR #35 broke the Bag (sorry!). This PR fixes what was broken.

Also restores the original behavior of `take_random` and `get_random` since `set.pop()` doesn't select which item to pop randomly.

Also updates `test_adventurelib.py` to obviate similar breaking changes in future.