### PR TITLE
Adds option to ignore signature enforcement in `@when`.

### DIFF
--- a/adventurelib.py
+++ b/adventurelib.py
@@ -382,14 +382,16 @@ def _register(command, func, context=None, kwargs={}):
     sig = inspect.signature(func)
     func_argnames = set(sig.parameters)
     when_argnames = set(pattern.argnames) | set(kwargs.keys())
-    if func_argnames != when_argnames:
-        raise InvalidCommand(
-            'The function %s%s has the wrong signature for @when(%r)' % (
-                func.__name__, sig, command
-            ) + '\n\nThe function arguments should be (%s)' % (
-                ', '.join(pattern.argnames + list(kwargs.keys()))
+    enforce_signature = kwargs.pop('enforce_signature', True)
+    if enforce_signature:
+        if func_argnames != when_argnames:
+            raise InvalidCommand(
+                'The function %s%s has the wrong signature for @when(%r)' % (
+                    func.__name__, sig, command
+                ) + '\n\nThe function arguments should be (%s)' % (
+                    ', '.join(pattern.argnames + list(kwargs.keys()))
+                )
             )
-        )
 
     commands.append((pattern, func, kwargs))
 

--- a/test_adventurelib.py
+++ b/test_adventurelib.py
@@ -153,6 +153,17 @@ def test_register_wrong_args():
             pass
 
 
+def test_register_wrong_args_unenforced():
+    """Same tests as above, but no exceptions are raised."""
+    @when('noargs', enforce_signature=False)
+    def noargs(argument):
+        pass
+
+    @when('onearg ARGUMENT', enforce_signature=False)
+    def noargs():
+        pass
+
+
 @pytest.mark.parametrize('ctx,expected', [
     (None, 'north'),
     ('confused', 'south'),

--- a/test_adventurelib.py
+++ b/test_adventurelib.py
@@ -141,6 +141,18 @@ def test_register_args():
     assert args == ['north']
 
 
+def test_register_wrong_args():
+    with pytest.raises(adventurelib.InvalidCommand):
+        @when('noargs')
+        def noargs(argument):
+            pass
+
+    with pytest.raises(adventurelib.InvalidCommand):
+        @when('onearg ARGUMENT')
+        def noargs():
+            pass
+
+
 @pytest.mark.parametrize('ctx,expected', [
     (None, 'north'),
     ('confused', 'south'),


### PR DESCRIPTION
This is useful when customizing/adding hooks to the `@when` decorator.