### PR TITLE
Replaces kwargs={} with **kwargs.

### DIFF
--- a/adventurelib.py
+++ b/adventurelib.py
@@ -376,8 +376,10 @@ class Bag(set):
         return obj
 
 
-def _register(command, func, context=None, **kwargs):
+def _register(command, func, context=None, kwargs=None):
     """Register func as a handler for the given command."""
+    if kwargs is None:
+        kwargs = {}
     pattern = Pattern(command, context)
     sig = inspect.signature(func)
     func_argnames = set(sig.parameters)
@@ -554,7 +556,7 @@ def no_command_matches(command):
 def when(command, context=None, **kwargs):
     """Decorator for command functions."""
     def dec(func):
-        _register(command, func, context, **kwargs)
+        _register(command, func, context, kwargs)
         return func
     return dec
 

--- a/adventurelib.py
+++ b/adventurelib.py
@@ -376,7 +376,7 @@ class Bag(set):
         return obj
 
 
-def _register(command, func, context=None, kwargs={}):
+def _register(command, func, context=None, **kwargs):
     """Register func as a handler for the given command."""
     pattern = Pattern(command, context)
     sig = inspect.signature(func)
@@ -554,7 +554,7 @@ def no_command_matches(command):
 def when(command, context=None, **kwargs):
     """Decorator for command functions."""
     def dec(func):
-        _register(command, func, context, kwargs)
+        _register(command, func, context, **kwargs)
         return func
     return dec
 


### PR DESCRIPTION
Mutable objects as default arguments can produce subtle bugs. `**kwargs` is also more idiomatic.