### PR TITLE
Add handling of bags on class attributes to Item similar as it is on Room

### DIFF
--- a/adventurelib.py
+++ b/adventurelib.py
@@ -208,6 +208,11 @@ class Item:
             for label in (name,) + aliases
         )
 
+        # Copy class Bags to instance variables
+        for k, v in vars(type(self)).items():
+            if isinstance(v, Bag):
+                setattr(self, k, deepcopy(v))
+
     def __repr__(self):
         return '%s(%s)' % (
             type(self).__name__,


### PR DESCRIPTION
Not sure if this is intentional. But the room class initializer contains code to deepcopy instances of `Bag` from class attributes to instance variables. Which allows to define

```
Room.items = Bag()
```
 and add items afterwards
```
room = Room(...)
room.items.add(item)
```
 
My son was using this pattern to build items which can contain other items (for example a shelf).

Because the initializer of class `Item` is missing that code to copy bags, this did not work as expected, because there will be only one instance of `Bag` for every item.

I suggest to add the same handling of bags to class `Item`.
